### PR TITLE
Check cran failure

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,6 @@
 ^README_files
 ^data-raw$
 ^CRAN-SUBMISSION$
+^\.Rhistory$
+^\.RData$
+^\.DS_Store$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: readepi
 Title: Read Data from Relational Database Management Systems and Health
     Information Systems
-Version: 1.0.5
+Version: 1.0.6
 Authors@R: c(
     person("Karim", "Mané", , "karim.mane@lshtm.ac.uk", role = "aut",
            comment = c(ORCID = "0000-0002-9892-2999")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: readepi
 Title: Read Data from Relational Database Management Systems and Health
     Information Systems
-Version: 1.0.4
+Version: 1.0.5
 Authors@R: c(
     person("Karim", "Mané", , "karim.mane@lshtm.ac.uk", role = "aut",
            comment = c(ORCID = "0000-0002-9892-2999")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# readepi 1.0.5
+
 # readepi 1.0.4
 
 * Corrected relative paths flagged by CRAN checks()

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# readepi 1.0.6
+
 # readepi 1.0.5
 
 # readepi 1.0.4

--- a/R/read_dhis2.R
+++ b/R/read_dhis2.R
@@ -13,12 +13,12 @@
 #'   # login to the DHIS2 instance
 #'   dhis2_login <- login(
 #'     type = "dhis2",
-#'     from = "https://smc.moh.gm/dhis",
-#'     user_name = "test",
-#'     password = "Gambia@123"
+#'     from = "https://play.im.dhis2.org/stable-2-41-8",
+#'     user_name = "admin",
+#'     password = "district"
 #'   )
-#'   program = "E5IUQuHg3Mg"
-#'   org_unit = "GcLhRNAFppR"
+#'   program = "IpHINAT79UW"
+#'   org_unit = "XjpmsLNjyrz"
 #'   data <- read_dhis2(
 #'     login = dhis2_login,
 #'     org_unit = org_unit,

--- a/R/read_dhis2.R
+++ b/R/read_dhis2.R
@@ -11,30 +11,18 @@
 #' @examples
 #' \dontrun{
 #'   # login to the DHIS2 instance
-#'   dhis2_login <- login(
-#'     type = "dhis2",
-#'     from = "https://play.im.dhis2.org/stable-2-41-8",
-#'     user_name = "admin",
-#'     password = "district"
-#'   )
-#'   program = "IpHINAT79UW"
-#'   org_unit = "XjpmsLNjyrz"
-#'   data <- read_dhis2(
-#'     login = dhis2_login,
-#'     org_unit = org_unit,
-#'     program = program
-#'   )
 #'
-#'   # fetch data from the test DHIS2 instance
 #'   dhis2_login <- login(
 #'     type = "dhis2",
 #'     from = "https://play.im.dhis2.org/stable-2-42-1",
 #'     user_name = "admin",
 #'     password = "district"
 #'   )
+#'
 #'   org_unit <- "DiszpKrYNg8"
 #'   program <- "IpHINAT79UW"
 #'
+#'  # fetch the data from specific program an unit
 #'   data <- read_dhis2(
 #'     login = dhis2_login,
 #'     org_unit = org_unit,

--- a/README.Rmd
+++ b/README.Rmd
@@ -28,7 +28,7 @@ knitr::opts_chunk$set(
 [![R-CMD-check](https://github.com/epiverse-trace/readepi/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/epiverse-trace/readepi/actions/workflows/R-CMD-check.yaml) [![Codecov test coverage](https://codecov.io/gh/epiverse-trace/readepi/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epiverse-trace/readepi?branch=main) [![lifecycle-concept](https://raw.githubusercontent.com/reconverse/reconverse.github.io/master/images/badge-maturing.svg)](https://www.reconverse.org/lifecycle.html#concept)
 <!-- badges: end -->
 
-**{{ packagename }}** is an R package for reading data from several health information systems (HIS) and relational database management systems (RDBMS).
+**{{ packagename }}** is an R package for reading data from health information systems (HIS) and relational database management systems (RDBMS).
 
 **{{ packagename }}** currently supports reading data from the followings:
 
@@ -71,7 +71,7 @@ The `read_rdbms()` function is used to import data from a variety of RDBMS, incl
 Users can read data from a RDBMS by providing a list with the query parameters of interest or an SQL query (for more information, see the **vignette**). 
 
 ```{r eval=FALSE}
-# CONNECT TO THE TEST MYSQL SERVER
+# CONNECT TO A TEST MYSQL SERVER
 rdbms_login <- readepi::login(
   from = "mysql-rfam-public.ebi.ac.uk",
   type = "mysql",
@@ -112,23 +112,23 @@ dat <- readepi::read_rdbms(
 # CONNECT TO A DHIS2 INSTANCE
 dhis2_login <- readepi::login(
   type = "dhis2",
-  from = "https://smc.moh.gm/dhis",
-  user_name = "test",
-  password = "Gambia@123"
+  from = "https://play.im.dhis2.org/stable-2-42-4",
+  user_name = "admin",
+  password = "district"
 )
 
-# IMPORT DATA FROM DHIS2 FOR THE SPECIFIED ORGANISATION UNIT AND PROGRAM IDs
+# IMPORT DATA FROM DHIS2 FOR A SPECIFIED ORGANISATION UNIT AND PROGRAM IDs
 data <- readepi::read_dhis2(
   login = dhis2_login,
-  org_unit = "GcLhRNAFppR",
-  program = "E5IUQuHg3Mg"
+  org_unit = "vRC0stJ5y9Q",
+  program = "IpHINAT79UW"
 )
 ```
 
 ### Reading data from SORMAS
 
 ```{r eval=FALSE}
-# CONNECT TO THE SORMAS SYSTEM
+# CONNECT TO A SORMAS SYSTEM
 sormas_login <- readepi::login(
   type = "sormas",
   from = "https://demo.sormas.org/sormas-rest",

--- a/README.Rmd
+++ b/README.Rmd
@@ -112,7 +112,7 @@ dat <- readepi::read_rdbms(
 # CONNECT TO A DHIS2 INSTANCE
 dhis2_login <- readepi::login(
   type = "dhis2",
-  from = "https://play.im.dhis2.org/stable-2-42-4",
+  from = "https://play.im.dhis2.org/stable-2-41-8",
   user_name = "admin",
   password = "district"
 )
@@ -120,7 +120,7 @@ dhis2_login <- readepi::login(
 # IMPORT DATA FROM DHIS2 FOR A SPECIFIED ORGANISATION UNIT AND PROGRAM IDs
 data <- readepi::read_dhis2(
   login = dhis2_login,
-  org_unit = "vRC0stJ5y9Q",
+  org_unit = "XjpmsLNjyrz",
   program = "IpHINAT79UW"
 )
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file. -->
-
 <!-- The code to render this README is stored in .github/workflows/render-readme.yaml -->
-
 <!-- Variables marked with double curly braces will be transformed beforehand: -->
-
 <!-- `packagename` is extracted from the DESCRIPTION file -->
-
 <!-- `gh_repo` is extracted via a special environment variable in GitHub Actions -->
 
 # readepi: Read data from health information systems <img src="man/figures/logo.svg" align="right" width="130"/>
@@ -21,9 +17,8 @@ coverage](https://codecov.io/gh/epiverse-trace/readepi/branch/main/graph/badge.s
 [![lifecycle-concept](https://raw.githubusercontent.com/reconverse/reconverse.github.io/master/images/badge-maturing.svg)](https://www.reconverse.org/lifecycle.html#concept)
 <!-- badges: end -->
 
-**readepi** is an R package for reading data from several health
-information systems (HIS) and relational database management systems
-(RDBMS).
+**readepi** is an R package for reading data from health information
+systems (HIS) and relational database management systems (RDBMS).
 
 **readepi** currently supports reading data from the followings:
 
@@ -84,7 +79,7 @@ parameters of interest or an SQL query (for more information, see the
 **vignette**).
 
 ``` r
-# CONNECT TO THE TEST MYSQL SERVER
+# CONNECT TO A TEST MYSQL SERVER
 rdbms_login <- readepi::login(
   from = "mysql-rfam-public.ebi.ac.uk",
   type = "mysql",
@@ -125,23 +120,23 @@ dat <- readepi::read_rdbms(
 # CONNECT TO A DHIS2 INSTANCE
 dhis2_login <- readepi::login(
   type = "dhis2",
-  from = "https://smc.moh.gm/dhis",
-  user_name = "test",
-  password = "Gambia@123"
+  from = "https://play.im.dhis2.org/stable-2-42-4",
+  user_name = "admin",
+  password = "district"
 )
 
-# IMPORT DATA FROM DHIS2 FOR THE SPECIFIED ORGANISATION UNIT AND PROGRAM IDs
+# IMPORT DATA FROM DHIS2 FOR A SPECIFIED ORGANISATION UNIT AND PROGRAM IDs
 data <- readepi::read_dhis2(
   login = dhis2_login,
-  org_unit = "GcLhRNAFppR",
-  program = "E5IUQuHg3Mg"
+  org_unit = "vRC0stJ5y9Q",
+  program = "IpHINAT79UW"
 )
 ```
 
 ### Reading data from SORMAS
 
 ``` r
-# CONNECT TO THE SORMAS SYSTEM
+# CONNECT TO A SORMAS SYSTEM
 sormas_login <- readepi::login(
   type = "sormas",
   from = "https://demo.sormas.org/sormas-rest",
@@ -197,11 +192,10 @@ By contributing to this project, you agree to abide by its terms.
 citation("readepi")
 #> To cite readepi in publications use:
 #> 
-#>   Karim Mané, Emmanuel Kabuga, Bankolé Ahadzie, Abdoelnaser
-#>   Degoot, Nuredin Mohammed, Bubacarr Bah (2025). readepi: Read
-#>   Data From Relational Database Management Systems and Health
-#>   Information Systems website:
-#>   https://epiverse-trace.github.io/readepi/
+#>   Karim Mané, Emmanuel Kabuga, Bankolé Ahadzie, Abdoelnaser Degoot,
+#>   Nuredin Mohammed, Bubacarr Bah (2025). readepi: Read Data From
+#>   Relational Database Management Systems and Health Information Systems
+#>   website: https://epiverse-trace.github.io/readepi/
 #> 
 #> A BibTeX entry for LaTeX users is
 #> 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ dat <- readepi::read_rdbms(
 # CONNECT TO A DHIS2 INSTANCE
 dhis2_login <- readepi::login(
   type = "dhis2",
-  from = "https://play.im.dhis2.org/stable-2-42-4",
+  from = "https://play.im.dhis2.org/stable-2-41-8",
   user_name = "admin",
   password = "district"
 )
@@ -128,7 +128,7 @@ dhis2_login <- readepi::login(
 # IMPORT DATA FROM DHIS2 FOR A SPECIFIED ORGANISATION UNIT AND PROGRAM IDs
 data <- readepi::read_dhis2(
   login = dhis2_login,
-  org_unit = "vRC0stJ5y9Q",
+  org_unit = "XjpmsLNjyrz",
   program = "IpHINAT79UW"
 )
 ```

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -26,7 +26,7 @@ This is a resubmission. In this version I have:
 
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
+0 errors | 0 warnings | 0 note
 
 * This is a new release.
 
@@ -34,10 +34,12 @@ This is a resubmission. In this version I have:
 
 This is a resubmission. In this version I have:
 
-* Updated the examples for reading data from DHIS2 in the vignettes to ensure full compliance with CRAN policies (e.g., no external API calls during checks).
-* Addressed all issues flagged in the previous CRAN checks.
-* Improved the readability and structure of the README and related documentation.
-* Verified that all examples and vignettes run without errors, warnings, or notes under `R CMD check --as-cran`.
+  * Updated the examples for reading data from DHIS2 in the vignettes to ensure 
+  full compliance with CRAN policies (e.g., no external API calls during checks).
+  * Addressed all issues flagged in the previous CRAN checks.
+  * Improved the readability and structure of the README and related documentation.
+  * Verified that all examples and vignettes run without errors, warnings, 
+  or notes under `R CMD check --as-cran`.
 
 ## R CMD check results
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -26,7 +26,7 @@ This is a resubmission. In this version I have:
 
 ## R CMD check results
 
-0 errors | 0 warnings | 0 note
+0 errors | 0 warnings | 1 note
 
 * This is a new release.
 
@@ -38,12 +38,10 @@ This is a resubmission. In this version I have:
   full compliance with CRAN policies (e.g., no external API calls during checks).
   * Addressed all issues flagged in the previous CRAN checks.
   * Improved the readability and structure of the README and related documentation.
-  * Verified that all examples and vignettes run without errors, warnings, 
-  or notes under `R CMD check --as-cran`.
-
+ 
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
+0 errors | 0 warnings | 0 note
 
 * This is a new release.
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -30,3 +30,18 @@ This is a resubmission. In this version I have:
 
 * This is a new release.
 
+## Resubmission
+
+This is a resubmission. In this version I have:
+
+* Updated the examples for reading data from DHIS2 in the vignettes to ensure full compliance with CRAN policies (e.g., no external API calls during checks).
+* Addressed all issues flagged in the previous CRAN checks.
+* Improved the readability and structure of the README and related documentation.
+* Verified that all examples and vignettes run without errors, warnings, or notes under `R CMD check --as-cran`.
+
+## R CMD check results
+
+0 errors | 0 warnings | 1 note
+
+* This is a new release.
+

--- a/man/read_dhis2.Rd
+++ b/man/read_dhis2.Rd
@@ -23,30 +23,18 @@ Import data from DHIS2
 \examples{
 \dontrun{
   # login to the DHIS2 instance
-  dhis2_login <- login(
-    type = "dhis2",
-    from = "https://play.im.dhis2.org/stable-2-41-8",
-    user_name = "admin",
-    password = "district"
-  )
-  program = "IpHINAT79UW"
-  org_unit = "XjpmsLNjyrz"
-  data <- read_dhis2(
-    login = dhis2_login,
-    org_unit = org_unit,
-    program = program
-  )
 
-  # fetch data from the test DHIS2 instance
   dhis2_login <- login(
     type = "dhis2",
     from = "https://play.im.dhis2.org/stable-2-42-1",
     user_name = "admin",
     password = "district"
   )
+
   org_unit <- "DiszpKrYNg8"
   program <- "IpHINAT79UW"
 
+ # fetch the data from specific program an unit
   data <- read_dhis2(
     login = dhis2_login,
     org_unit = org_unit,

--- a/man/read_dhis2.Rd
+++ b/man/read_dhis2.Rd
@@ -25,12 +25,12 @@ Import data from DHIS2
   # login to the DHIS2 instance
   dhis2_login <- login(
     type = "dhis2",
-    from = "https://smc.moh.gm/dhis",
-    user_name = "test",
-    password = "Gambia@123"
+    from = "https://play.im.dhis2.org/stable-2-41-8",
+    user_name = "admin",
+    password = "district"
   )
-  program = "E5IUQuHg3Mg"
-  org_unit = "GcLhRNAFppR"
+  program = "IpHINAT79UW"
+  org_unit = "XjpmsLNjyrz"
   data <- read_dhis2(
     login = dhis2_login,
     org_unit = org_unit,

--- a/tests/testthat/test-authenticate.R
+++ b/tests/testthat/test-authenticate.R
@@ -54,9 +54,9 @@ test_that("login fails with a wrong URL", {
 test_that("login works as expected when connecting to DHIS2", {
   dhis2_login <- login(
     type = "dhis2",
-    from = "https://smc.moh.gm/dhis",
-    user_name = "test",
-    password = "Gambia@123"
+    from = "https://play.im.dhis2.org/stable-2-41-8",
+    user_name = "admin",
+    password = "district"
   )
   expect_true(inherits(dhis2_login, "httr2_response"))
   expect_identical(dhis2_login$status_code, 200L)
@@ -67,8 +67,8 @@ test_that("login fails with a wrong URL for DHIS2", {
     login(
       type = "dhis2",
       from = "fake-url",
-      user_name = "test",
-      password = "Gambia@123"
+      user_name = "admin",
+      password = "district"
     ),
     regexp = cat("Incorrect domain name in the provided URL!")
   )
@@ -78,9 +78,9 @@ test_that("login fails if username is not provided", {
   expect_error(
     login(
       type = "dhis2",
-      from = "https://smc.moh.gm/dhis",
+      from = "https://play.im.dhis2.org/stable-2-41-8",
       user_name = NULL,
-      password = "Gambia@123"
+      password = "district"
     ),
     regexp = cat("Assertion on',user_name,'failed: user_name must be provided.")
   )

--- a/tests/testthat/test-read_dhis2-helpers.R
+++ b/tests/testthat/test-read_dhis2-helpers.R
@@ -5,9 +5,9 @@ testthat::skip_on_ci()
 test_that("get_org_unit_as_long with a non-data frame object", {
   dhis2_login <- login(
     type = "dhis2",
-    from = "https://smc.moh.gm/dhis",
-    user_name = "test",
-    password = "Gambia@123"
+    from = "https://play.im.dhis2.org/stable-2-41-8",
+    user_name = "admin",
+    password = "district"
   )
   expect_error(
     get_org_unit_as_long(
@@ -41,13 +41,13 @@ test_that("get_org_unit_as_long with a non-data frame object", {
 test_that("check_program fails as expected", {
   dhis2_login <- login(
     type = "dhis2",
-    from = "https://smc.moh.gm/dhis",
-    user_name = "test",
-    password = "Gambia@123"
+    from = "https://play.im.dhis2.org/stable-2-41-8",
+    user_name = "admin",
+    password = "district"
   )
   programs <- get_programs(login = dhis2_login)
   program_name <- "fake_program"
-  program_id <- "E5IUQuHgXXX"
+  program_id <- "IpHINAT7XXX"
 
   expect_error(
     check_program(
@@ -65,7 +65,7 @@ test_that("check_program fails as expected", {
     regexp = cat("You provided an incorrect program ID or name.")
   )
 
-  program_id <- c("E5IUQuHg3Mg", "E5IUQuHgXXX")
+  program_id <- c("IpHINAT79UW", "E5IUQuHgXXX")
   expect_message(
     check_program(
       login = dhis2_login,

--- a/tests/testthat/test-read_dhis2.R
+++ b/tests/testthat/test-read_dhis2.R
@@ -6,14 +6,14 @@ test_that("read_dhis2 works as expected", {
   # establish the connection to the system
   dhis2_login <- login(
     type = "dhis2",
-    from = "https://smc.moh.gm/dhis",
-    user_name = "test",
-    password = "Gambia@123"
+    from = "https://play.im.dhis2.org/stable-2-41-8",
+    user_name = "admin",
+    password = "district"
   )
 
   # use the program and organisation unit IDs
-  program <- "E5IUQuHg3Mg"
-  org_unit <- "GcLhRNAFppR"
+  program <- "IpHINAT79UW"
+  org_unit <- "XjpmsLNjyrz"
 
   # import data from the specified program and org unit
   data <- read_dhis2(
@@ -22,11 +22,11 @@ test_that("read_dhis2 works as expected", {
     program = program
   )
   expect_s3_class(data, "data.frame")
-  expect_identical(dim(data), c(1116L, 69L))
+  expect_identical(dim(data), c(40L, 26L))
 
   # use the program and organisation unit names
-  program <- "Child Registration & Treatment "
-  org_unit <- "Keneba"
+  program <- "Child Programme"
+  org_unit <- "Magbaft MCHP"
 
   # import data from the specified program and org unit
   data <- read_dhis2(
@@ -35,7 +35,7 @@ test_that("read_dhis2 works as expected", {
     program = program
   )
   expect_s3_class(data, "data.frame")
-  expect_identical(dim(data), c(1116L, 69L))
+  expect_identical(dim(data), c(40L, 26L))
 })
 
 test_that("read_dhis2 fails as expected", {
@@ -44,10 +44,10 @@ test_that("read_dhis2 fails as expected", {
     read_dhis2(
       login = dhis2_login,
       org_unit = "I0v1SmdpPzT",
-      program = "Child Registration & Treatment "
+      program = "Child Programme"
     ),
     regexp = cat(
-      "The specified organisation unit does not run the program E5IUQuHg3Mg"
+      "The specified organisation unit does not run the program IpHINAT79UW"
     )
   )
 })

--- a/vignettes/readepi.Rmd
+++ b/vignettes/readepi.Rmd
@@ -119,7 +119,7 @@ dat |>
                          fixed_thead = TRUE)
 ```
 
-# Reading data from HIS
+# Reading data from HIS APIs
 
 The current version of **{readepi}** supports reading data from two common HIS: [DHIS2](https://dhis2.org/), and [SORMAS](https://sormas.org/).
 

--- a/vignettes/readepi.Rmd
+++ b/vignettes/readepi.Rmd
@@ -25,7 +25,7 @@ The main objective of the **{readepi}** package is to simplify the process of re
 The current implementation of **{readepi}** provides functions for reading data from two common HIS: ([SORMAS](https://sormas.org/), [DHIS2](https://dhis2.org/), and RDBMS such as MS SQL, MySQL, PostgreSQL, and SQLite. Other utility functions for accessing relevant files and data are also included in this package.
 
 ```{r setup, eval=TRUE}
-# LOAD readepi
+# Load readepi
 library(readepi)
 ```
 
@@ -46,15 +46,8 @@ To read data from RDBMS and HIS, the user is expected to have, at least, read ac
 -   `port`: The port ID (optional). This is only needed for connecting to RDBMS only.
 
 ```{r}
-# CONNECT TO A DHIS2 INSTANCE
-dhis2_login <- login(
-  type = "dhis2",
-  from  = "https://smc.moh.gm/dhis",
-  user_name = "test",
-  password  = "Gambia@123"
-)
 
-# CONNECT TO THE TEST MYSQL SERVER
+# Connect to a test MYSQL server
 rdbms_login <- login(
   type = "mysql",
   from = "mysql-rfam-public.ebi.ac.uk",
@@ -65,7 +58,15 @@ rdbms_login <- login(
   port = 4497
 )
 
-# CONNECT TO A SORMAS SYSTEM
+# Connect to a DHIS2 instance
+dhis2_login <- login(
+  type = "dhis2",
+  from  = "https://play.im.dhis2.org/stable-2-42-4",
+  user_name = "admin",
+  password  = "district"
+)
+
+# Connect to a SORMAS system
 sormas_login <- login(
   type = "sormas",
   from  = "https://demo.sormas.org/sormas-rest",
@@ -168,9 +169,9 @@ In the current version, the `login()` function only supports basic authenticatio
 # CONNECT TO A DHIS2 INSTANCE
 dhis2_login <- login(
   type = "dhis2",
-  from = "https://smc.moh.gm/dhis",
-  user_name = "test",
-  password = "Gambia@123"
+  from = "https://play.im.dhis2.org/stable-2-42-4",
+  user_name = "admin",
+  password = "district"
 )
 ```
 
@@ -227,7 +228,7 @@ data_elements |>
 # GET THE LIST OF ALL PROGRAM STAGES FOR A GIVEN PROGRAM ID
 program_stages <- get_program_stages(
   login = dhis2_login,
-  program = "E5IUQuHg3Mg",
+  program = "LqUtsxvm60C",
   programs = programs
 )
 ```
@@ -248,7 +249,7 @@ It is important to know that not all organisation units are registered for a spe
 # GET THE LIST OF ORGANISATION UNITS RUNNING THE SPECIFIED PROGRAM
 target_org_units <- get_program_org_units(
     login = dhis2_login,
-    program = "E5IUQuHg3Mg",
+    program = "LqUtsxvm60C",
     org_units = org_units
   )
 ```
@@ -269,15 +270,8 @@ After identifying the correct organisation unit and program IDs or names, users 
 # IMPORT DATA FROM DHIS2 FOR THE SPECIFIED ORGANISATION UNIT AND PROGRAM IDs
 data <- read_dhis2(
   login = dhis2_login,
-  org_unit = "GcLhRNAFppR",
-  program = "E5IUQuHg3Mg"
-)
-
-# IMPORT DATA FROM DHIS2 FOR THE SPECIFIED ORGANISATION UNIT AND PROGRAM NAMES
-data <- read_dhis2(
-  login = dhis2_login,
-  org_unit = "Keneba",
-  program = "Child Registration & Treatment "
+  org_unit = "vRC0stJ5y9Q",
+  program = "IpHINAT79UW"
 )
 ```
 

--- a/vignettes/readepi.Rmd
+++ b/vignettes/readepi.Rmd
@@ -66,7 +66,7 @@ rdbms_login <- login(
 )
 
 # CONNECT TO A SORMAS SYSTEM
-dhis2_login <- login(
+sormas_login <- login(
   type = "sormas",
   from  = "https://demo.sormas.org/sormas-rest",
   user_name = "SurvSup",

--- a/vignettes/readepi.Rmd
+++ b/vignettes/readepi.Rmd
@@ -35,7 +35,7 @@ Users of operating systems other than Microsoft need to have the appropriate MS 
 
 ## Authentication
 
-To read data from RDBMS and HIS, the user is expected to have, at least, read access to the system. To establish the connection to their system, users can call the `login()` function with the following arguments:
+To read data from RDBMS and HIS APIs, the user is expected to have, at least, read access to the system. To establish the connection to their system, users can call the `login()` function with the following arguments:
 
 -   `from`: The URL to the system of interest. For APIs, this must be the base URL (required).
 -   `type`: The source name (required). The current version of the package covers the following RDBMS and HIS types: "ms sql", "mysql", "postgresql", "sqlite", "dhis2", "sormas".
@@ -44,36 +44,6 @@ To read data from RDBMS and HIS, the user is expected to have, at least, read ac
 -   `driver_name`: The driver name (optional). This is only needed for connecting to RDBMS only.
 -   `db_name`: The database name (optional). This is only needed for connecting to RDBMS only.
 -   `port`: The port ID (optional). This is only needed for connecting to RDBMS only.
-
-```{r}
-
-# Connect to a test MYSQL server
-rdbms_login <- login(
-  type = "mysql",
-  from = "mysql-rfam-public.ebi.ac.uk",
-  user_name = "rfamro",
-  password = "",
-  driver_name = "",
-  db_name = "Rfam",
-  port = 4497
-)
-
-# Connect to a DHIS2 instance
-dhis2_login <- login(
-  type = "dhis2",
-  from  = "https://play.im.dhis2.org/stable-2-42-4",
-  user_name = "admin",
-  password  = "district"
-)
-
-# Connect to a SORMAS system
-sormas_login <- login(
-  type = "sormas",
-  from  = "https://demo.sormas.org/sormas-rest",
-  user_name = "SurvSup",
-  password  = "Lk5R7JXeZSEc"
-)
-```
 
 ## Reading data from RDBMS
 
@@ -169,7 +139,7 @@ In the current version, the `login()` function only supports basic authenticatio
 # CONNECT TO A DHIS2 INSTANCE
 dhis2_login <- login(
   type = "dhis2",
-  from = "https://play.im.dhis2.org/stable-2-42-4",
+  from = "https://play.im.dhis2.org/stable-2-41-8",
   user_name = "admin",
   password = "district"
 )
@@ -228,7 +198,7 @@ data_elements |>
 # GET THE LIST OF ALL PROGRAM STAGES FOR A GIVEN PROGRAM ID
 program_stages <- get_program_stages(
   login = dhis2_login,
-  program = "LqUtsxvm60C",
+  program = "IpHINAT79UW",
   programs = programs
 )
 ```
@@ -249,7 +219,7 @@ It is important to know that not all organisation units are registered for a spe
 # GET THE LIST OF ORGANISATION UNITS RUNNING THE SPECIFIED PROGRAM
 target_org_units <- get_program_org_units(
     login = dhis2_login,
-    program = "LqUtsxvm60C",
+    program = "IpHINAT79UW",
     org_units = org_units
   )
 ```
@@ -270,7 +240,7 @@ After identifying the correct organisation unit and program IDs or names, users 
 # IMPORT DATA FROM DHIS2 FOR THE SPECIFIED ORGANISATION UNIT AND PROGRAM IDs
 data <- read_dhis2(
   login = dhis2_login,
-  org_unit = "vRC0stJ5y9Q",
+  org_unit = "XjpmsLNjyrz",
   program = "IpHINAT79UW"
 )
 ```


### PR DESCRIPTION
This PR addresses issues reported in CRAN checks:
https://cran.r-project.org/web/checks/check_results_readepi.html

Changes include:

* Updated all examples in the README and vignettes to ensure compliance with CRAN policies, particularly by including working  DHIS2 calls during package checks. The Gambia sever is out due to license  renewal issue.
* Improved the readability and organization of the README and related documentation.