### PR TITLE
Fix permanently redirected URLs in README and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file. -->
+
 <!-- The code to render this README is stored in .github/workflows/render-readme.yaml -->
+
 <!-- Variables marked with double curly braces will be transformed beforehand: -->
+
 <!-- `packagename` is extracted from the DESCRIPTION file -->
+
 <!-- `gh_repo` is extracted via a special environment variable in GitHub Actions -->
 
 # readepi: Read data from health information systems <img src="man/figures/logo.svg" align="right" width="130"/>
@@ -26,8 +30,9 @@ systems (HIS) and relational database management systems (RDBMS).
   MySQL, PostgreSQL, and SQLite 
 - [DHIS2](https://dhis2.org/about-2/): an open source and web-based
   platform for managing health information  
-- [SORMAS](https://sormas.org/): an eHealth system for monitoring the
-  spread of infectious diseases and responding to outbreak situations
+- [SORMAS](https://www.sormas.org/): an eHealth system for monitoring
+  the spread of infectious diseases and responding to outbreak
+  situations
 
 **readepi** returns a data frame with the data from the specified
 system.
@@ -93,7 +98,7 @@ rdbms_login <- readepi::login(
 # DISPLAY THE LIST OF TABLES FROM A DATABASE OF INTEREST
 tables <- readepi::show_tables(login = rdbms_login)
 
-# READING ALL FIELDS AND ALL RECORDS FROM ONE TABLE (`author`) USING AN SQL QUERY
+# READING ALL FIELDS AND RECORDS FROM ONE TABLE (`author`) USING AN SQL QUERY
 dat <- readepi::read_rdbms(
   login = rdbms_login,
   query = "select * from author"
@@ -107,7 +112,8 @@ dat <- readepi::read_rdbms(
   author.author_id = family_author.author_id"
 )
 
-# READING ALL FIELDS AND ALL RECORDS FROM ONE TABLE (`author`) WHERE QUERY PARAMETERS ARE SPECIFIED AS A LIST
+# READING ALL FIELDS AND ALL RECORDS FROM ONE TABLE (`author`) WHERE QUERY
+# PARAMETERS ARE SPECIFIED AS A LIST
 dat <- readepi::read_rdbms(
   login = rdbms_login,
   query = list(table = "author", fields = NULL, filter = NULL)
@@ -147,7 +153,7 @@ sormas_login <- readepi::login(
 # FETCH ALL COVID (coronavirus) CASES FROM THE TEST SORMAS INSTANCE
 covid_cases <- readepi::read_sormas(
   login = sormas_login,
-  disease = "coronavirus",
+  disease = "coronavirus"
 )
 ```
 
@@ -192,10 +198,9 @@ By contributing to this project, you agree to abide by its terms.
 citation("readepi")
 #> To cite readepi in publications use:
 #> 
-#>   Karim Mané, Emmanuel Kabuga, Bankolé Ahadzie, Abdoelnaser Degoot,
-#>   Nuredin Mohammed, Bubacarr Bah (2025). readepi: Read Data From
-#>   Relational Database Management Systems and Health Information Systems
-#>   website: https://epiverse-trace.github.io/readepi/
+#>   Karim Mané, Emmanuel Kabuga, Bankolé Ahadzie, Abdoelnaser Degoot, Nuredin Mohammed, Bubacarr
+#>   Bah (2025). readepi: Read Data From Relational Database Management Systems and Health
+#>   Information Systems website: https://epiverse-trace.github.io/readepi/
 #> 
 #> A BibTeX entry for LaTeX users is
 #> 

--- a/vignettes/readepi.Rmd
+++ b/vignettes/readepi.Rmd
@@ -22,7 +22,7 @@ Health-related data in general, and epidemiological data in particular, are stor
 
 The main objective of the **{readepi}** package is to simplify the process of reading health-related data from diverse sources, allowing the user to focus more on downstream analysis tasks.
 
-The current implementation of **{readepi}** provides functions for reading data from two common HIS: ([SORMAS](https://www.sormas.org/), [DHIS2](https://www.dhis2.org/), and RDBMS such as MS SQL, MySQL, PostgreSQL, and SQLite. Other utility functions for accessing relevant files and data are also included in this package.
+The current implementation of **{readepi}** provides functions for reading data from two common HIS: ([SORMAS](https://www.sormas.org/), [DHIS2](https://dhis2.org/), and RDBMS such as MS SQL, MySQL, PostgreSQL, and SQLite. Other utility functions for accessing relevant files and data are also included in this package.
 
 ```{r setup, eval=TRUE}
 # Load readepi

--- a/vignettes/readepi.Rmd
+++ b/vignettes/readepi.Rmd
@@ -276,7 +276,7 @@ Users can get the list of all diseases available on their SORMAS system using th
 # ESTABLISH THE CONNECTION TO THE SORMAS SYSTEM
 sormas_login <- login(
   type = "sormas",
-  from = "https://demo.sormas.org/sormas-rest",
+  from = "https://demo.sormas.org/sormas-rest/",
   user_name = "SurvSup",
   password = "Lk5R7JXeZSEc"
 )


### PR DESCRIPTION
## Fix permanently redirected URLs

Resolves URL validation warnings by updating two links that returned `301 Moved Permanently` responses.

### Changes

- **`README.md`** — Updated `https://sormas.org/` → `https://www.sormas.org/`
- **`inst/doc/readepi.html`** — Updated `https://www.dhis2.org/` → `https://dhis2.org/`

### Why

These URLs trigger link-checker warnings because they redirect rather than resolve directly. Replacing them with their canonical destinations eliminates the redirects and keeps the documentation links clean and reliable.