### PR TITLE
Stabledhis2 logging

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -78,10 +78,13 @@ references:
   url: https://www.R-project.org/
   authors:
   - name: R Core Team
+    website: https://ror.org/02zz1nj61
   institution:
     name: R Foundation for Statistical Computing
+    website: https://ror.org/05qewa988
     address: Vienna, Austria
   year: '2026'
+  doi: 10.32614/R.manuals
   version: '>= 4.1.0'
 - type: software
   title: checkmate

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,5 +58,5 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 SystemRequirements: odbc, libmariadbclient-dev
+Config/roxygen2/version: 8.0.0

--- a/R/authenticate.R
+++ b/R/authenticate.R
@@ -41,9 +41,9 @@
 #' \dontrun{
 #'   dhi2s_login <- login(
 #'     type = "dhis2",
-#'     from = "https://smc.moh.gm/dhis",
-#'     user_name = "test",
-#'     password = "Gambia@123"
+#'     from = "https://play.im.dhis2.org/stable-2-41-8-1",
+#'     user_name = "admin",
+#'     password = "district"
 #'   )
 #' }
 #'

--- a/R/read_dhis2-helpers.R
+++ b/R/read_dhis2-helpers.R
@@ -45,7 +45,7 @@ get_api_version <- function(login) {
 #' @examples
 #' \dontrun{
 #'   dhis2_log <- dhis2_login(
-#'     base_url = "https://play.im.dhis2.org/stable-2-42-1",
+#'     base_url = "https://play.im.dhis2.org/stable-2-42-8-1",
 #'     user_name = "admin",
 #'     password = "district"
 #'   )

--- a/README.Rmd
+++ b/README.Rmd
@@ -113,7 +113,7 @@ dat <- readepi::read_rdbms(
 # CONNECT TO A DHIS2 INSTANCE
 dhis2_login <- readepi::login(
   type = "dhis2",
-  from = "https://play.im.dhis2.org/stable-2-41-8",
+  from = "https://play.im.dhis2.org/stable-2-41-8-1",
   user_name = "admin",
   password = "district"
 )

--- a/man/dhis2_login.Rd
+++ b/man/dhis2_login.Rd
@@ -23,7 +23,7 @@ Establish connection to a DHIS2 instance
 \examples{
 \dontrun{
   dhis2_log <- dhis2_login(
-    base_url = "https://play.im.dhis2.org/stable-2-42-1",
+    base_url = "https://play.im.dhis2.org/stable-2-42-8-1",
     user_name = "admin",
     password = "district"
   )

--- a/man/login.Rd
+++ b/man/login.Rd
@@ -62,9 +62,9 @@ bearer token).
 \dontrun{
   dhi2s_login <- login(
     type = "dhis2",
-    from = "https://smc.moh.gm/dhis",
-    user_name = "test",
-    password = "Gambia@123"
+    from = "https://play.im.dhis2.org/stable-2-41-8-1",
+    user_name = "admin",
+    password = "district"
   )
 }
 

--- a/tests/testthat/test-authenticate.R
+++ b/tests/testthat/test-authenticate.R
@@ -54,7 +54,7 @@ test_that("login fails with a wrong URL", {
 test_that("login works as expected when connecting to DHIS2", {
   dhis2_login <- login(
     type = "dhis2",
-    from = "https://play.im.dhis2.org/stable-2-41-8",
+    from = "https://play.im.dhis2.org/stable-2-41-8-1",
     user_name = "admin",
     password = "district"
   )

--- a/tests/testthat/test-read_dhis2-helpers.R
+++ b/tests/testthat/test-read_dhis2-helpers.R
@@ -5,7 +5,7 @@ testthat::skip_on_ci()
 test_that("get_org_unit_as_long with a non-data frame object", {
   dhis2_login <- login(
     type = "dhis2",
-    from = "https://play.im.dhis2.org/stable-2-41-8",
+    from = "https://play.im.dhis2.org/stable-2-41-8-1",
     user_name = "admin",
     password = "district"
   )
@@ -41,7 +41,7 @@ test_that("get_org_unit_as_long with a non-data frame object", {
 test_that("check_program fails as expected", {
   dhis2_login <- login(
     type = "dhis2",
-    from = "https://play.im.dhis2.org/stable-2-41-8",
+    from = "https://play.im.dhis2.org/stable-2-41-8-1",
     user_name = "admin",
     password = "district"
   )

--- a/tests/testthat/test-read_dhis2.R
+++ b/tests/testthat/test-read_dhis2.R
@@ -6,7 +6,7 @@ test_that("read_dhis2 works as expected", {
   # establish the connection to the system
   dhis2_login <- login(
     type = "dhis2",
-    from = "https://play.im.dhis2.org/stable-2-41-8",
+    from = "https://play.im.dhis2.org/stable-2-41-8-1",
     user_name = "admin",
     password = "district"
   )

--- a/vignettes/readepi.Rmd
+++ b/vignettes/readepi.Rmd
@@ -141,7 +141,7 @@ In the current version, the `login()` function only supports basic authenticatio
 # CONNECT TO A DHIS2 INSTANCE
 dhis2_login <- login(
   type = "dhis2",
-  from = "https://play.im.dhis2.org/stable-2-41-8",
+  from = "https://play.im.dhis2.org/stable-2-41-8-1",
   user_name = "admin",
   password = "district"
 )


### PR DESCRIPTION
This PR updates all test examples, vignettes, and the README to use the correct stable DHIS2 server versions. This ensures consistency across package documentation and testing resources and improves compatibility with current DHIS2 deployments.

Closes #105